### PR TITLE
README.md correctly indicates how to start server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you wish to run the API back-end on your own machine or server, you must inst
 	
 To start the API server:
 
-    node bin/www
+    npm start
 
 #API Testing#
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "start": "./runserver"
   },
   "dependencies": {
   "body-parser": "~1.0.0",


### PR DESCRIPTION
npm start is now the preferred method. Currently it calls ./runserver
